### PR TITLE
Revert "Bump babel-preset-gatsby from 2.24.0 to 3.3.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@tailwindcss/typography": "^0.5.8",
         "autoprefixer": "^10.4.13",
-        "babel-preset-gatsby": "^3.3.1",
+        "babel-preset-gatsby": "^2.24.0",
         "disqus-react": "^1.1.5",
         "downshift": "^7.0.1",
         "gatsby": "^2.23.9",
@@ -3111,9 +3111,9 @@
       "integrity": "sha512-nEBLOa0JgtqahmPrnJZ18epLiFBzxhdKgo4uhN3TaBFRmM30pEVrS9FAEV4tg92d8PTdU+dYQx2lnpPyFMgMcg=="
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.2.0.tgz",
-      "integrity": "sha512-Z9LFPzfoJi4mflGWV+rv7o7ZbMU5oAU9VmzCgL240KnqDW65Y2HFCT3MW06/ITJSnbVLacmcEJA8phywK7JinQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.1.2.tgz",
+      "integrity": "sha512-TyVLn3S/+ikMDsh0gbKv2YydKClN8HaJDDpONlaZR+LVJmsxLFUgA+O7zu59h9+f9gX1aj/ahw9wqa6rosmrYQ==",
       "cpu": [
         "arm64"
       ],
@@ -3123,9 +3123,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.2.0.tgz",
-      "integrity": "sha512-vq0tT8sjZsy4JdSqmadWVw6f66UXqUCabLmUVHZwUFzMgtgoIIQjT4VVRHKvlof3P/dMCkbMJ5hB1oJ9OWHaaw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.1.2.tgz",
+      "integrity": "sha512-YPXtcVkhmVNoMGlqp81ZHW4dMxK09msWgnxtsDpSiZwTzUBG2N+No2bsr7WMtBKCVJMSD6mbAl7YhKUqkp/Few==",
       "cpu": [
         "x64"
       ],
@@ -3135,9 +3135,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.2.0.tgz",
-      "integrity": "sha512-SaJ3Qq4lX9Syd2xEo9u3qPxi/OB+5JO/ngJKK97XDpa1C587H9EWYO6KD8995DAjSinWvdHKRrCOXVUC5fvGOg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.1.2.tgz",
+      "integrity": "sha512-42R4MAFeIeNn+L98qwxAt360bwzX2Kf0ZQkBBucJ2Ircza3asoY4CDbgiu9VWklq8gWJVSJSJBwDI+c/THiWkA==",
       "cpu": [
         "arm"
       ],
@@ -3147,9 +3147,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.2.0.tgz",
-      "integrity": "sha512-hlxxLdRmPyq16QCutUtP8Tm6RDWcyaLsRssaHROatgnkOxdleMTgetf9JsdncL8vLh7FVy/RN9i3XR5dnb9cRA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.1.2.tgz",
+      "integrity": "sha512-vHZ2JiOWF2+DN9lzltGbhtQNzDo8fKFGrf37UJrgqxU0yvtERrzUugnfnX1wmVfFhSsF8OxrfqiNOUc5hko1Zg==",
       "cpu": [
         "arm64"
       ],
@@ -3159,9 +3159,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.2.0.tgz",
-      "integrity": "sha512-94y5PJrSOqUNcFKmOl7z319FelCLAE0rz/jPCWS+UtdMZvpa4jrQd+cJPQCLp2Fes1yAW/YUQj/Di6YVT3c3Iw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.1.2.tgz",
+      "integrity": "sha512-RjRoRxg7Q3kPAdUSC5EUUPlwfMkIVhmaRTIe+cqHbKrGZ4M6TyCA/b5qMaukQ/1CHWrqYY2FbKOAU8Hg0pQFzg==",
       "cpu": [
         "x64"
       ],
@@ -3171,9 +3171,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.2.0.tgz",
-      "integrity": "sha512-XrC0JzsqQSvOyM3t04FMLO6z5gCuhPE6k4FXuLK5xf52ZbdvcFe1yBmo7meCew9B8G2f0T9iu9t3kfTYRYROgA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.1.2.tgz",
+      "integrity": "sha512-rIZVR48zA8hGkHIK7ED6+ZiXsjRCcAVBJbm8o89OKAMTmEAQ2QvoOxoiu3w2isAaWwzgtQIOFIqHwvZDyLKCvw==",
       "cpu": [
         "x64"
       ],
@@ -6458,9 +6458,9 @@
       }
     },
     "node_modules/babel-preset-gatsby": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-3.3.1.tgz",
-      "integrity": "sha512-FbHNlxrCs4MMT+d98YjDAuqTv+q41MLsbNt2nQkjofZ+3jWhy1Fh/eyXL1KdkrqFe6ClioO3YJGwaqEswIHqTQ==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-2.24.0.tgz",
+      "integrity": "sha512-EFPclGESPH2grzmN3bX6UoDi+3fgk+zLR5lDPGGaOgrUOEdxETMYdnz9VA37mjI2W/a+x/xCeE7qJRnNCJtn4g==",
       "dependencies": {
         "@babel/plugin-proposal-class-properties": "^7.14.0",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
@@ -6475,11 +6475,11 @@
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "babel-plugin-macros": "^3.1.0",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-        "gatsby-core-utils": "^4.3.1",
-        "gatsby-legacy-polyfills": "^3.3.0"
+        "gatsby-core-utils": "^3.24.0",
+        "gatsby-legacy-polyfills": "^2.24.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.15.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.11.6",
@@ -13135,9 +13135,9 @@
       }
     },
     "node_modules/gatsby-core-utils": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-4.3.1.tgz",
-      "integrity": "sha512-KKNWjnqOPTsRJRHFUcyUGE7NW058tL54SiUJUqZiaeEuXDhglFR0kclXQdN50j1a+RCLa05X2x6XSeWYlzCung==",
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.24.0.tgz",
+      "integrity": "sha512-P4tbcYOJ1DSYKRP4gIAR9Xta/d/AzjmsK2C6PzX7sNcGnviDKtAIoeV9sE0kNXOqBfUCez25zmAi2cq8NlaxKw==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "ci-info": "2.0.0",
@@ -13156,7 +13156,7 @@
         "xdg-basedir": "^4.0.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.15.0"
       }
     },
     "node_modules/gatsby-core-utils/node_modules/@sindresorhus/is": {
@@ -13234,9 +13234,9 @@
       }
     },
     "node_modules/gatsby-core-utils/node_modules/got": {
-      "version": "11.8.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "version": "11.8.5",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -13290,9 +13290,9 @@
       }
     },
     "node_modules/gatsby-core-utils/node_modules/keyv": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
-      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.0.tgz",
+      "integrity": "sha512-2YvuMsA+jnFGtBareKqgANOEKe1mk3HKiXu2fRmAfyxG0MJAywNhi5ttWA3PMjl4NmpyjZNbFifR2vNjW1znfA==",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -13379,9 +13379,9 @@
       }
     },
     "node_modules/gatsby-legacy-polyfills": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/gatsby-legacy-polyfills/-/gatsby-legacy-polyfills-3.3.0.tgz",
-      "integrity": "sha512-4Ahk3i8Zix+j2czQXK0QAbbeoLkh0m/KdbRLjIzcWW8r4XXutqr9b756lPQZQzq90thgIU4uZALk25J7hwdbFw==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/gatsby-legacy-polyfills/-/gatsby-legacy-polyfills-2.24.0.tgz",
+      "integrity": "sha512-3O/SlgTtK3z+rbp9UPgA5Hc0AgFbklpgZ1nx40HfgsbRcSHl81INzyIPjN9Fpp9BM4GOknAAL7VPfeilTn2mog==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "core-js-compat": "3.9.0"
@@ -22312,17 +22312,17 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/msgpackr": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.1.tgz",
-      "integrity": "sha512-05fT4J8ZqjYlR4QcRDIhLCYKUOHXk7C/xa62GzMKj74l3up9k2QZ3LgFc6qWdsPHl91QA2WLWqWc8b8t7GLNNw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.7.2.tgz",
+      "integrity": "sha512-mWScyHTtG6TjivXX9vfIy2nBtRupaiAj0HQ2mtmpmYujAmqZmaaEVPaSZ1NKLMvicaMLFzEaMk0ManxMRg8rMQ==",
       "optionalDependencies": {
-        "msgpackr-extract": "^2.2.0"
+        "msgpackr-extract": "^2.1.2"
       }
     },
     "node_modules/msgpackr-extract": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.2.0.tgz",
-      "integrity": "sha512-0YcvWSv7ZOGl9Od6Y5iJ3XnPww8O7WLcpYMDwX+PAA/uXLDtyw94PJv9GLQV/nnp3cWlDhMoyKZIQLrx33sWog==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.1.2.tgz",
+      "integrity": "sha512-cmrmERQFb19NX2JABOGtrKdHMyI6RUyceaPBQ2iRz9GnDkjBWFjNJC0jyyoOfZl2U/LZE3tQCCQc4dlRyA8mcA==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -22332,12 +22332,12 @@
         "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
       },
       "optionalDependencies": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.2.0",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "2.2.0",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "2.2.0",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "2.2.0",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "2.2.0",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "2.2.0"
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.1.2",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "2.1.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "2.1.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "2.1.2",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "2.1.2",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "2.1.2"
       }
     },
     "node_modules/multicast-dns": {
@@ -52377,39 +52377,39 @@
       "integrity": "sha512-nEBLOa0JgtqahmPrnJZ18epLiFBzxhdKgo4uhN3TaBFRmM30pEVrS9FAEV4tg92d8PTdU+dYQx2lnpPyFMgMcg=="
     },
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.2.0.tgz",
-      "integrity": "sha512-Z9LFPzfoJi4mflGWV+rv7o7ZbMU5oAU9VmzCgL240KnqDW65Y2HFCT3MW06/ITJSnbVLacmcEJA8phywK7JinQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.1.2.tgz",
+      "integrity": "sha512-TyVLn3S/+ikMDsh0gbKv2YydKClN8HaJDDpONlaZR+LVJmsxLFUgA+O7zu59h9+f9gX1aj/ahw9wqa6rosmrYQ==",
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.2.0.tgz",
-      "integrity": "sha512-vq0tT8sjZsy4JdSqmadWVw6f66UXqUCabLmUVHZwUFzMgtgoIIQjT4VVRHKvlof3P/dMCkbMJ5hB1oJ9OWHaaw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.1.2.tgz",
+      "integrity": "sha512-YPXtcVkhmVNoMGlqp81ZHW4dMxK09msWgnxtsDpSiZwTzUBG2N+No2bsr7WMtBKCVJMSD6mbAl7YhKUqkp/Few==",
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.2.0.tgz",
-      "integrity": "sha512-SaJ3Qq4lX9Syd2xEo9u3qPxi/OB+5JO/ngJKK97XDpa1C587H9EWYO6KD8995DAjSinWvdHKRrCOXVUC5fvGOg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.1.2.tgz",
+      "integrity": "sha512-42R4MAFeIeNn+L98qwxAt360bwzX2Kf0ZQkBBucJ2Ircza3asoY4CDbgiu9VWklq8gWJVSJSJBwDI+c/THiWkA==",
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.2.0.tgz",
-      "integrity": "sha512-hlxxLdRmPyq16QCutUtP8Tm6RDWcyaLsRssaHROatgnkOxdleMTgetf9JsdncL8vLh7FVy/RN9i3XR5dnb9cRA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.1.2.tgz",
+      "integrity": "sha512-vHZ2JiOWF2+DN9lzltGbhtQNzDo8fKFGrf37UJrgqxU0yvtERrzUugnfnX1wmVfFhSsF8OxrfqiNOUc5hko1Zg==",
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.2.0.tgz",
-      "integrity": "sha512-94y5PJrSOqUNcFKmOl7z319FelCLAE0rz/jPCWS+UtdMZvpa4jrQd+cJPQCLp2Fes1yAW/YUQj/Di6YVT3c3Iw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.1.2.tgz",
+      "integrity": "sha512-RjRoRxg7Q3kPAdUSC5EUUPlwfMkIVhmaRTIe+cqHbKrGZ4M6TyCA/b5qMaukQ/1CHWrqYY2FbKOAU8Hg0pQFzg==",
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.2.0.tgz",
-      "integrity": "sha512-XrC0JzsqQSvOyM3t04FMLO6z5gCuhPE6k4FXuLK5xf52ZbdvcFe1yBmo7meCew9B8G2f0T9iu9t3kfTYRYROgA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.1.2.tgz",
+      "integrity": "sha512-rIZVR48zA8hGkHIK7ED6+ZiXsjRCcAVBJbm8o89OKAMTmEAQ2QvoOxoiu3w2isAaWwzgtQIOFIqHwvZDyLKCvw==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -55016,9 +55016,9 @@
       }
     },
     "babel-preset-gatsby": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-3.3.1.tgz",
-      "integrity": "sha512-FbHNlxrCs4MMT+d98YjDAuqTv+q41MLsbNt2nQkjofZ+3jWhy1Fh/eyXL1KdkrqFe6ClioO3YJGwaqEswIHqTQ==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-2.24.0.tgz",
+      "integrity": "sha512-EFPclGESPH2grzmN3bX6UoDi+3fgk+zLR5lDPGGaOgrUOEdxETMYdnz9VA37mjI2W/a+x/xCeE7qJRnNCJtn4g==",
       "requires": {
         "@babel/plugin-proposal-class-properties": "^7.14.0",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
@@ -55033,8 +55033,8 @@
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "babel-plugin-macros": "^3.1.0",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-        "gatsby-core-utils": "^4.3.1",
-        "gatsby-legacy-polyfills": "^3.3.0"
+        "gatsby-core-utils": "^3.24.0",
+        "gatsby-legacy-polyfills": "^2.24.0"
       },
       "dependencies": {
         "babel-plugin-macros": {
@@ -60543,9 +60543,9 @@
       }
     },
     "gatsby-core-utils": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-4.3.1.tgz",
-      "integrity": "sha512-KKNWjnqOPTsRJRHFUcyUGE7NW058tL54SiUJUqZiaeEuXDhglFR0kclXQdN50j1a+RCLa05X2x6XSeWYlzCung==",
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.24.0.tgz",
+      "integrity": "sha512-P4tbcYOJ1DSYKRP4gIAR9Xta/d/AzjmsK2C6PzX7sNcGnviDKtAIoeV9sE0kNXOqBfUCez25zmAi2cq8NlaxKw==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "ci-info": "2.0.0",
@@ -60615,9 +60615,9 @@
           }
         },
         "got": {
-          "version": "11.8.6",
-          "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-          "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+          "version": "11.8.5",
+          "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+          "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
           "requires": {
             "@sindresorhus/is": "^4.0.0",
             "@szmarczak/http-timer": "^4.0.5",
@@ -60657,9 +60657,9 @@
           }
         },
         "keyv": {
-          "version": "4.5.2",
-          "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
-          "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.0.tgz",
+          "integrity": "sha512-2YvuMsA+jnFGtBareKqgANOEKe1mk3HKiXu2fRmAfyxG0MJAywNhi5ttWA3PMjl4NmpyjZNbFifR2vNjW1znfA==",
           "requires": {
             "json-buffer": "3.0.1"
           }
@@ -60718,9 +60718,9 @@
       }
     },
     "gatsby-legacy-polyfills": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/gatsby-legacy-polyfills/-/gatsby-legacy-polyfills-3.3.0.tgz",
-      "integrity": "sha512-4Ahk3i8Zix+j2czQXK0QAbbeoLkh0m/KdbRLjIzcWW8r4XXutqr9b756lPQZQzq90thgIU4uZALk25J7hwdbFw==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/gatsby-legacy-polyfills/-/gatsby-legacy-polyfills-2.24.0.tgz",
+      "integrity": "sha512-3O/SlgTtK3z+rbp9UPgA5Hc0AgFbklpgZ1nx40HfgsbRcSHl81INzyIPjN9Fpp9BM4GOknAAL7VPfeilTn2mog==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "core-js-compat": "3.9.0"
@@ -67252,25 +67252,25 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "msgpackr": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.1.tgz",
-      "integrity": "sha512-05fT4J8ZqjYlR4QcRDIhLCYKUOHXk7C/xa62GzMKj74l3up9k2QZ3LgFc6qWdsPHl91QA2WLWqWc8b8t7GLNNw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.7.2.tgz",
+      "integrity": "sha512-mWScyHTtG6TjivXX9vfIy2nBtRupaiAj0HQ2mtmpmYujAmqZmaaEVPaSZ1NKLMvicaMLFzEaMk0ManxMRg8rMQ==",
       "requires": {
-        "msgpackr-extract": "^2.2.0"
+        "msgpackr-extract": "^2.1.2"
       }
     },
     "msgpackr-extract": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.2.0.tgz",
-      "integrity": "sha512-0YcvWSv7ZOGl9Od6Y5iJ3XnPww8O7WLcpYMDwX+PAA/uXLDtyw94PJv9GLQV/nnp3cWlDhMoyKZIQLrx33sWog==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.1.2.tgz",
+      "integrity": "sha512-cmrmERQFb19NX2JABOGtrKdHMyI6RUyceaPBQ2iRz9GnDkjBWFjNJC0jyyoOfZl2U/LZE3tQCCQc4dlRyA8mcA==",
       "optional": true,
       "requires": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.2.0",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "2.2.0",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "2.2.0",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "2.2.0",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "2.2.0",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.1.2",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "2.1.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "2.1.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "2.1.2",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "2.1.2",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "2.1.2",
         "node-gyp-build-optional-packages": "5.0.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@tailwindcss/typography": "^0.5.8",
     "autoprefixer": "^10.4.13",
-    "babel-preset-gatsby": "^3.3.1",
+    "babel-preset-gatsby": "^2.24.0",
     "disqus-react": "^1.1.5",
     "downshift": "^7.0.1",
     "gatsby": "^2.23.9",


### PR DESCRIPTION
Reverts csillacs/writersgroup#311